### PR TITLE
Add curl installation command for Ubuntu Docker images

### DIFF
--- a/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
+++ b/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
@@ -20,7 +20,7 @@ ENV LC_ALL en_US.UTF-8
 
 ARG DETECT_SOURCE=<detectsource>
 
-RUN set -e; if [ $(curl --silent -L -w '%{http_code}' -o /synopsys-detect.jar --create-dirs ${DETECT_SOURCE}) != "200" ]; then echo "Unable to download Detect jar from ${DETECT_SOURCE}"; exit 1; fi
+RUN if [ $(curl --silent -L -w '%{http_code}' -o /synopsys-detect.jar --create-dirs ${DETECT_SOURCE}) != "200" ]; then echo "Unable to download Detect jar from ${DETECT_SOURCE}"; exit 1; fi
 
 # Define Docker Image entrypoint
 ENTRYPOINT ["java", "-jar", "/synopsys-detect.jar", "--detect.source.path=/source", "--detect.output.path=/output", "--detect.phone.home.passthrough.invoked.by.image=true"]

--- a/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
+++ b/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:22.10
 # Update
 RUN apt-get update
 
+RUN apt-get -y install curl
+
 # Java
 RUN apt-get -y install default-jre-headless
 ENV BDS_JAVA_HOME=/usr/lib/jvm/default-java

--- a/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
+++ b/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
@@ -20,7 +20,7 @@ ENV LC_ALL en_US.UTF-8
 
 ARG DETECT_SOURCE=<detectsource>
 
-RUN if [ $(curl --silent -L -w '%{http_code}' -o /synopsys-detect.jar --create-dirs ${DETECT_SOURCE}) != "200" ]; then echo "Unable to download Detect jar from ${DETECT_SOURCE}"; exit 1; fi
+RUN set -e; if [ $(curl --silent -L -w '%{http_code}' -o /synopsys-detect.jar --create-dirs ${DETECT_SOURCE}) != "200" ]; then echo "Unable to download Detect jar from ${DETECT_SOURCE}"; exit 1; fi
 
 # Define Docker Image entrypoint
 ENTRYPOINT ["java", "-jar", "/synopsys-detect.jar", "--detect.source.path=/source", "--detect.output.path=/output", "--detect.phone.home.passthrough.invoked.by.image=true"]


### PR DESCRIPTION
curl needs to be installed before attempting a curl download of Detect JAR in Detect's Ubuntu Docker images

JIRA Issue: https://jira-sig.internal.synopsys.com/browse/IDETECT-3860