### PR TITLE
Sanity updates to address curl vulnerability issues found in POP scans

### DIFF
--- a/java/11/alpine/3.13/detect/template/buildless/Dockerfile
+++ b/java/11/alpine/3.13/detect/template/buildless/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.18
 
 # Update, get bash
 RUN apk update && apk add bash && apk add curl

--- a/java/11/alpine/3.13/detect/template/standard/Dockerfile
+++ b/java/11/alpine/3.13/detect/template/standard/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.18
 
 # Update, get bash
 RUN apk update && apk add bash && apk add curl

--- a/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
+++ b/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:23.04
 
 # Update
 RUN apt-get update
@@ -21,7 +21,7 @@ ENV LC_ALL en_US.UTF-8
 
 ARG DETECT_SOURCE=<detectsource>
 
-RUN wget --quiet -O /synopsys-detect.jar ${DETECT_SOURCE}
+RUN wget -O /synopsys-detect.jar --server-response ${DETECT_SOURCE}
 
 # Define Docker Image entrypoint
 ENTRYPOINT ["java", "-jar", "/synopsys-detect.jar", "--detect.source.path=/source", "--detect.output.path=/output", "--detect.phone.home.passthrough.invoked.by.image=true"]

--- a/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
+++ b/java/11/ubuntu/22.10/detect/template/iac/Dockerfile
@@ -1,9 +1,10 @@
-FROM ubuntu:23.04
+FROM ubuntu:23.10
 
 # Update
 RUN apt-get update
 
-RUN apt-get -y install curl
+# Install wget
+RUN apt-get -y install wget
 
 # Java
 RUN apt-get -y install default-jre-headless
@@ -20,7 +21,7 @@ ENV LC_ALL en_US.UTF-8
 
 ARG DETECT_SOURCE=<detectsource>
 
-RUN if [ $(curl --silent -L -w '%{http_code}' -o /synopsys-detect.jar --create-dirs ${DETECT_SOURCE}) != "200" ]; then echo "Unable to download Detect jar from ${DETECT_SOURCE}"; exit 1; fi
+RUN wget --quiet -O /synopsys-detect.jar ${DETECT_SOURCE}
 
 # Define Docker Image entrypoint
 ENTRYPOINT ["java", "-jar", "/synopsys-detect.jar", "--detect.source.path=/source", "--detect.output.path=/output", "--detect.phone.home.passthrough.invoked.by.image=true"]


### PR DESCRIPTION
**For Alpine images**
Updated base image version to 3.18 for buildless and standard Detect images.
Alpine 3.18 pulls the latest curl version i.e. 8.4.0. [[Reference](https://curl.se/download.html#:~:text=Travis%20Lee-,Linux%20%2D%20Alpine,-Linux%20Alpine)]

**For the Ubuntu image**
Latest Ubuntu version available is 23.10 that supports a maximum curl version of 8.2.1. [[Reference](https://curl.se/download.html#:~:text=binary-,Linux%20Ubuntu%20mantic,-8.2.1)]
As of now, KB has flagged all versions below 8.4.0 as vulnerable. Hence we have switched from curl to wget in the Ubuntu image.
For wget, the command `wget --quiet -O /synopsys-detect.jar ${DETECT_SOURCE}` will simply download, rename and save the jar in root directory `/`. 
The previous curl command had some additional flags. Below is why they are not present in wget:
- `-L` is to retry the request if a redirect URL is provided. wget handles this by default with a `--max-redirect` option with a default value of 20. We would only need to set this flag if we want to allow more than 20 redirects.
- `--create-dirs` is not needed here since we only download one JAR always (no recursive downloads) and save it in the root dir.
- `-w '%{http_code}'` - Unfortunately, this can only be achieved via parsing the response from wget (there is no convenient way like the one curl provides to output only the http status code):
```
if [ $(wget --quiet -O /synopsys-detect.jar --server-response ${DETECT_SOURCE} 2>&1 | awk '/HTTP/{print $2}') != "200" ]; then echo "Unable to download Detect jar from ${DETECT_SOURCE}"; exit 1; fi
```
However, I noticed in some cases the response header provided more than one `HTTP` strings so it didn't match accurately with `awk`. The logic for parsing this was getting really messy for the benefit of the echo message that it provides, hence have removed it to keep the download command simple.