### PR TITLE
create new 3.23 alpine files

### DIFF
--- a/java/11/alpine/3.23/detect/template/buildless/Dockerfile
+++ b/java/11/alpine/3.23/detect/template/buildless/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:3.23
+
+# Update, upgrade, and add required packages
+RUN apk --no-cache update && \
+    apk --no-cache upgrade && \
+    apk --no-cache add bash curl
+
+# Java, use headless as it brings in less dependencies
+RUN apk --no-cache add openjdk11-jre-headless
+
+ENV BDS_JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+
+# Download Detect jar
+
+ARG DETECT_SOURCE=<detectsource>
+
+RUN if [ $(curl --silent -L -w '%{http_code}' -o /detect.jar --create-dirs ${DETECT_SOURCE}) != "200" ]; then echo "Unable to download Detect jar from ${DETECT_SOURCE}"; exit 1; fi
+
+# Define Docker Image entrypoint
+ENTRYPOINT ["java", "-jar", "/detect.jar", "--detect.source.path=/source", "--detect.output.path=/output", "--detect.phone.home.passthrough.invoked.by.image=true", "--detect.accuracy.required=NONE"]

--- a/java/11/alpine/3.23/detect/template/standard/Dockerfile
+++ b/java/11/alpine/3.23/detect/template/standard/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.23
+
+# Update, upgrade, and add required packages
+RUN apk --no-cache update && \
+    apk --no-cache upgrade && \
+    apk --no-cache add bash curl
+
+# Required for standalone nuget inspector
+RUN apk --no-cache add libstdc++ gcompat icu
+
+# Java, use headless as it brings in less dependencies
+RUN apk --no-cache add openjdk11-jre-headless
+
+ENV BDS_JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+
+# Download Detect jar
+
+ARG DETECT_SOURCE=<detectsource>
+
+RUN if [ $(curl --silent -L -w '%{http_code}' -o /detect.jar --create-dirs ${DETECT_SOURCE}) != "200" ]; then echo "Unable to download Detect jar from ${DETECT_SOURCE}"; exit 1; fi
+
+# Define Docker Image entrypoint
+ENTRYPOINT ["java", "-jar", "/detect.jar", "--detect.source.path=/source", "--detect.output.path=/output", "--detect.phone.home.passthrough.invoked.by.image=true"]


### PR DESCRIPTION
This is a new PR that replaces the previous https://github.com/blackducksoftware/detect-docker/pull/15

It is essentially the same thing but changes the folder structure to account for the move to Alpine 3.23. If you wish to compare the Dockerfiles you can look at the one in this PR and compare it with the one located at
java/11/alpine/3.13/detect/template/buildless/Dockerfile and java/11/alpine/3.13/detect/template/standard/Dockerfile 